### PR TITLE
fix: 🐛 set private of root package.son to true

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Publish to npm
         env:
-          GITHUB_TOKEN: ${{secrets.GH_TOKEN}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
         run: |
           pnpm nx run-many -target=release

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "main"
     ]
   },
+  "private": true,
   "dependencies": {
     "@nx/remix": "19.8.6",
     "@remix-run/node": "^2.8.1",

--- a/packages/git-cz-config/release.config.cjs
+++ b/packages/git-cz-config/release.config.cjs
@@ -16,6 +16,7 @@ module.exports = {
       },
     ],
     '@semantic-release/npm',
+    '@semantic-release/github',
     [
       '@semantic-release/git',
       {

--- a/packages/react-markdown-mermaid/release.config.cjs
+++ b/packages/react-markdown-mermaid/release.config.cjs
@@ -16,6 +16,7 @@ module.exports = {
       },
     ],
     '@semantic-release/npm',
+    '@semantic-release/github',
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a `private` property to the project configuration, indicating it will not be published publicly.
	- Integrated the `@semantic-release/github` plugin into the release process for both `git-cz-config` and `react-markdown-mermaid` packages, enabling automated release management with GitHub.
- **Chores**
	- Updated the GitHub token secret in the publishing workflow for improved authentication during the release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->